### PR TITLE
Use CP 3.0.0

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -8,6 +8,7 @@
 
 $packages = [
   'confluent-kafka-2.11',
+  'git',
   'java-1.8.0-openjdk-headless',
   'java-1.8.0-openjdk-devel',
   'krb5-workstation',

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -14,7 +14,8 @@ $packages = [
   'krb5-workstation',
   'krb5-server',
   'krb5-libs',
-  'haveged'
+  'haveged',
+  'maven'
 ]
 
 $ssl_port = 9093

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -9,6 +9,7 @@
 $packages = [
   'confluent-kafka-2.11',
   'java-1.8.0-openjdk-headless',
+  'java-1.8.0-openjdk-devel',
   'krb5-workstation',
   'krb5-server',
   'krb5-libs',

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -7,7 +7,7 @@
 # puppet module install saz-ssh
 
 $packages = [
-  'confluent-kafka-2.11.7',
+  'confluent-kafka-2.11',
   'java-1.8.0-openjdk-headless',
   'krb5-workstation',
   'krb5-server',
@@ -68,10 +68,10 @@ service{'firewall':
 }
 yumrepo{'confluent':
   ensure   => 'present',
-  descr    => 'Confluent repository for 2.0.x packages',
-  baseurl  => 'http://packages.confluent.io/rpm/2.0',
+  descr    => 'Confluent repository for 3.0.x packages',
+  baseurl  => 'http://packages.confluent.io/rpm/3.0',
   gpgcheck => 1,
-  gpgkey   => 'http://packages.confluent.io/rpm/2.0/archive.key',
+  gpgkey   => 'http://packages.confluent.io/rpm/3.0/archive.key',
 } ->
 package{$packages:
   ensure => 'installed'


### PR DESCRIPTION
Also, this PR installs JDK 8, git, and maven, so that we can build, package, and run Kafka Streams examples from https://github.com/confluentinc/examples against a secure Kafka cluster.
